### PR TITLE
Enable ToC and heading anchors

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -51,3 +51,8 @@
   url = "/99-service/"
   weight = 99
   identifier = "service"
+
+[markup]
+  [markup.tableOfContents]
+    startLevel = 2
+    endLevel = 4

--- a/prosto-pro-sobak/layouts/_default/single.html
+++ b/prosto-pro-sobak/layouts/_default/single.html
@@ -1,0 +1,14 @@
+{{ define "main" }}
+<main>
+  <article>
+    <h1>{{ .Title }}</h1>
+    {{ if .TableOfContents }}
+      <aside class="toc">
+        <h2>Оглавление</h2>
+        {{ .TableOfContents }}
+      </aside>
+    {{ end }}
+    {{ .Content }}
+  </article>
+</main>
+{{ end }}

--- a/prosto-pro-sobak/layouts/partials/head.html
+++ b/prosto-pro-sobak/layouts/partials/head.html
@@ -2,4 +2,44 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ .Title }}</title>
+  <style>
+    .toc {
+      padding: 1rem;
+      border: 1px solid #ccc;
+      background: #f9f9f9;
+      margin-bottom: 2rem;
+    }
+    .toc a {
+      text-decoration: none;
+      display: block;
+      margin: 0.25rem 0;
+      color: #444;
+    }
+    .toc a:hover {
+      text-decoration: underline;
+    }
+    .anchor-link {
+      visibility: hidden;
+      margin-left: 0.5rem;
+      font-size: 0.8em;
+    }
+    h2:hover .anchor-link,
+    h3:hover .anchor-link,
+    h4:hover .anchor-link {
+      visibility: visible;
+    }
+  </style>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('main h2, main h3, main h4').forEach(function (h) {
+        if (h.id) {
+          var a = document.createElement('a');
+          a.className = 'anchor-link';
+          a.href = '#' + h.id;
+          a.textContent = '#';
+          h.appendChild(a);
+        }
+      });
+    });
+  </script>
 </head>


### PR DESCRIPTION
## Summary
- add Table of Contents to article layout
- style ToC and add anchor links via JS
- configure TableOfContents levels in config

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686145ca9ca0832bb34fa7a7244fbbe2