### PR TITLE
Fix menu link for care section

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,7 +18,7 @@
 
 [[menu.main]]
   name = "Питание"
-  url = "/04-food/"
+  url = "/04-care/"
   weight = 4
   identifier = "food"
 


### PR DESCRIPTION
## Summary
- fix URL path for `food` menu entry to `/04-care/`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6861930a30dc832babdf20206f7a8960